### PR TITLE
Use all namespaces by default when looking for out-of-resource pods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ $ python main.py [options]
 - --regions: List of comma-separated regions in order of preference. E.g. `us-west-2,us-east-1` will use "us-west-2" as the
 primary region and "us-east-1" as the secondary.
 - --kubeconfig: Path to kubeconfig YAML file. Leave blank if running in Kubernetes to use [service account](http://kubernetes.io/docs/user-guide/service-accounts/).
+- --pod-namespace: The namespace to look for out-of-resource pods in. By default, this will look in all namespaces.
 - --idle-threshold: This defines the maximum duration (in seconds) for an instance to be kept idle.
 - --type-idle-threshold: For each instance type, we keep a few running and idle so the cluster has spare capacity for different types of requests. This defines the maximum duration (in seconds) for an instance to be kept idle.
 - --aws-access-key: AWS access key. Can also be specified in environment variable `AWS_ACCESS_KEY`

--- a/main.py
+++ b/main.py
@@ -24,6 +24,9 @@ DEBUG_LOGGING_MAP = {
 @click.option("--kubeconfig", default=None,
               help='Full path to kubeconfig file. If not provided, '
                    'we assume that we\'re running on kubernetes.')
+@click.option("--pod-namespace", default=None,
+              help='The namespace to look for out-of-resource pods in. By '
+                   'default, this will look in all namespaces.')
 @click.option("--idle-threshold", default=3600)
 @click.option("--type-idle-threshold", default=3600*24*7)
 @click.option("--over-provision", default=5)
@@ -45,7 +48,7 @@ DEBUG_LOGGING_MAP = {
                    "for more verbosity.",
               type=click.IntRange(0, 3, clamp=True),
               count=True)
-def main(cluster_name, regions, sleep, kubeconfig,
+def main(cluster_name, regions, sleep, kubeconfig, pod_namespace,
          aws_access_key, aws_secret_key, datadog_api_key,
          idle_threshold, type_idle_threshold,
          over_provision, instance_init_time, no_scale, no_maintenance,
@@ -64,6 +67,7 @@ def main(cluster_name, regions, sleep, kubeconfig,
                       aws_secret_key=aws_secret_key,
                       regions=regions.split(','),
                       kubeconfig=kubeconfig,
+                      pod_namespace=pod_namespace,
                       idle_threshold=idle_threshold,
                       instance_init_time=instance_init_time,
                       type_idle_threshold=type_idle_threshold,

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -75,6 +75,7 @@ class TestCluster(unittest.TestCase):
             aws_secret_key='',
             regions=['us-west-2', 'us-east-1', 'us-west-1'],
             kubeconfig='~/.kube/config',
+            pod_namespace=None,
             idle_threshold=60,
             instance_init_time=60,
             type_idle_threshold=60,


### PR DESCRIPTION
Fixes #58 .