### PR TITLE
Add in logging about missing ASGs when using --dry-run.

### DIFF
--- a/autoscaler/cluster.py
+++ b/autoscaler/cluster.py
@@ -547,24 +547,32 @@ class Cluster(object):
                 # do nothing
                 pass
             elif state == ClusterNodeState.UNDER_UTILIZED_DRAINABLE:
-                if not self.dry_run:
-                    if not asg:
+                if not asg:
+                    if not self.dry_run:
                         logger.warn(
                             'Cannot find ASG for node %s. Not cordoned.', node)
                     else:
-                        node.cordon()
-                        node.drain(pods_by_node.get(node.name, []),
-                                   notifier=self.notifier)
+                        logger.warn(
+                            '[Dry run] Cannot find ASG for node %s. Would have '
+                            'been unable to cordon.', node)
+                elif not self.dry_run:
+                    node.cordon()
+                    node.drain(pods_by_node.get(node.name, []),
+                               notifier=self.notifier)
                 else:
                     logger.info(
                         '[Dry run] Would have drained and cordoned %s', node)
             elif state == ClusterNodeState.IDLE_SCHEDULABLE:
-                if not self.dry_run:
-                    if not asg:
+                if not asg:
+                    if not self.dry_run:
                         logger.warn(
                             'Cannot find ASG for node %s. Not cordoned.', node)
                     else:
-                        node.cordon()
+                        logger.warn(
+                            '[Dry run] Cannot find ASG for node %s. Would have '
+                            'been unable to cordon.', node)
+                elif not self.dry_run:
+                    node.cordon()
                 else:
                     logger.info('[Dry run] Would have cordoned %s', node)
             elif state == ClusterNodeState.BUSY_UNSCHEDULABLE:
@@ -575,12 +583,16 @@ class Cluster(object):
                     logger.info('[Dry run] Would have uncordoned %s', node)
             elif state == ClusterNodeState.IDLE_UNSCHEDULABLE:
                 # remove it from asg
-                if not self.dry_run:
-                    if not asg:
+                if not asg:
+                    if not self.dry_run:
                         logger.warn(
                             'Cannot find ASG for node %s. Not terminated.', node)
                     else:
-                        asg.scale_node_in(node)
+                        logger.warn(
+                            '[Dry run] Cannot find ASG for node %s. Would have '
+                            'been unable to terminate.', node)
+                elif not self.dry_run:
+                    asg.scale_node_in(node)
                 else:
                     logger.info('[Dry run] Would have scaled in %s', node)
             elif state == ClusterNodeState.INSTANCE_TERMINATED:


### PR DESCRIPTION
Prior to this change, `--dry-run` wouldn't properly report errors about missing ASGs.