### PR TITLE
Fix handling of "Updating" or "Failed" Scale Sets

### DIFF
--- a/autoscaler/azure.py
+++ b/autoscaler/azure.py
@@ -186,13 +186,13 @@ class AzureVirtualScaleSet(AutoScalingGroup):
                     new_group_capacity = scale_set.capacity + 1
                 else:
                     new_group_capacity = min(_SCALE_SET_SIZE_LIMIT, scale_set.capacity + scale_out)
-                scale_out -= (new_group_capacity - scale_set.capacity)
                 if scale_set.provisioning_state == 'Updating':
                     logger.warn("Update of {} already in progress".format(scale_set.name))
                     continue
                 if scale_set.provisioning_state == 'Failed':
                     logger.error("{} failed provisioning. Skipping it for scaling.".format(scale_set.name))
                     continue
+                scale_out -= (new_group_capacity - scale_set.capacity)
                 # Update our cached version
                 self.scale_sets[scale_set.name].capacity = new_group_capacity
                 futures.append(self.client.update_scale_set(scale_set, new_group_capacity))

--- a/test/test_azure.py
+++ b/test/test_azure.py
@@ -16,6 +16,30 @@ from autoscaler.azure_api import AzureScaleSet, AzureWrapper
 
 
 class TestCluster(unittest.TestCase):
+    def test_failed_scale_up(self):
+        region = 'test'
+        mock_client = mock.Mock()
+        mock_client.virtual_machine_scale_set_vms = mock.Mock()
+        mock_client.virtual_machine_scale_set_vms.list = mock.Mock(return_value=[])
+        mock_client.virtual_machine_scale_sets = mock.Mock()
+        mock_client.virtual_machine_scale_sets.create_or_update = mock.Mock()
+
+        monitor_client = mock.Mock()
+        monitor_client.activity_logs = mock.Mock()
+        monitor_client.activity_logs.list = mock.Mock(return_value=[])
+
+        instance_type = 'Standard_D1_v2'
+        resource_group = 'test-resource-group'
+        failed_scale_set = AzureScaleSet(region, resource_group, 'test-scale-set1', instance_type, 0, 'Failed')
+        scale_set = AzureScaleSet(region, resource_group, 'test-scale-set2', instance_type, 0, 'Succeeded')
+
+        virtual_scale_set = AzureVirtualScaleSet(region, resource_group, AzureWrapper(mock_client, monitor_client), instance_type, False, [failed_scale_set, scale_set], [])
+
+        virtual_scale_set.scale(5)
+
+        mock_client.virtual_machine_scale_sets.create_or_update.assert_called_once()
+        self.assertEqual(mock_client.virtual_machine_scale_sets.create_or_update.call_args[1]['parameters'].sku.capacity, 5)
+
     def test_scale_up(self):
         region = 'test'
         mock_client = mock.Mock()


### PR DESCRIPTION
Previously, they were being counted as if they had successfully scaled.