### PR TITLE
Adds ability to use boto default credentials setup for session

### DIFF
--- a/autoscaler/cluster.py
+++ b/autoscaler/cluster.py
@@ -112,6 +112,9 @@ class Cluster(object):
                 aws_access_key_id=aws_access_key,
                 aws_secret_access_key=aws_secret_key,
                 region_name=aws_regions[0])  # provide a default region
+        else:
+            # let boto do the setup. allows for other methods like kube2iam
+            self.session = boto3.session.Session(region_name=aws_regions[0])
         self.autoscaling_groups = autoscaling_groups.AutoScalingGroups(
             session=self.session, regions=aws_regions,
             cluster_name=cluster_name)

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ def main(cluster_name, aws_regions, azure_resource_groups, azure_slow_scale_clas
     logger.setLevel(DEBUG_LOGGING_MAP.get(verbose, logging.CRITICAL))
 
     aws_regions_list = aws_regions.split(',') if aws_regions else []
-    if not (aws_secret_key and aws_access_key) and aws_regions_list:
+    if not aws_regions_list:
         logger.error("Missing AWS credentials. Please provide aws-access-key and aws-secret-key.")
         sys.exit(1)
 


### PR DESCRIPTION
When the `aws_access_key` and `aws_secret_key` are not given, the api now can use all methods that boto supports for setting up credentials.

Allows credentials to be read from metadata and work with IAM Roles, instead of just IAM Users.
Allows setup with [kube2iam](https://github.com/jtblin/kube2iam) with 
`iam.amazonaws.com/role: arn:aws:iam::<rolename>`

Resolves #13 